### PR TITLE
Hotfix: fix GC option in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENV LD_PRELOAD="/usr/lib64/libjemalloc.so"
 # Set max Java heap usage as percentage of total available memory.
 ENTRYPOINT ["java", \
 	"-Dlogback.configurationFile=/home/logback.xml", \
-    "-XX:+UseG3GC", \
+    "-XX:+UseG1GC", \
     "-XX:MaxGCPauseMillis=20", \
     "-XX:InitiatingHeapOccupancyPercent=35", \
     "-XX:MetaspaceSize=96m", \

--- a/jpo-conflictmonitor/pom.xml
+++ b/jpo-conflictmonitor/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>usdot.jpo.ode</groupId>
   <artifactId>jpo-conflictmonitor</artifactId>
-  <version>3.1.0</version>
+  <version>3.1.1</version>
   <packaging>jar</packaging>
   <name>jpo-conflictmonitor</name>
   <url>http://maven.apache.org</url>


### PR DESCRIPTION
Hotfix: fix GC option in Dockerfile preventing docker image from starting up in release.

Version number incremented to 3.1.1

Tested by verifying it can start up in Docker via docker compose.